### PR TITLE
More changes related to 37498c5

### DIFF
--- a/examples/cg/cg.h
+++ b/examples/cg/cg.h
@@ -23,7 +23,6 @@
 
 #ifdef STARPU_USE_CUDA
 #include <cuda.h>
-#include <cublas.h>
 #endif
 
 #define DOUBLE

--- a/examples/cholesky/cholesky_kernels.c
+++ b/examples/cholesky/cholesky_kernels.c
@@ -22,7 +22,6 @@
 #include "cholesky.h"
 #include "../common/blas.h"
 #if defined(STARPU_USE_CUDA)
-#include <cublas.h>
 #include <starpu_cublas_v2.h>
 #include "starpu_cusolver.h"
 #if defined(STARPU_HAVE_MAGMA)
@@ -197,7 +196,7 @@ static inline void chol_common_codelet_update_trsm(void *descr[], int s, void *_
 	unsigned ny21 = STARPU_MATRIX_GET_NX(descr[1]);
 
 #ifdef STARPU_USE_CUDA
-	cublasStatus status;
+	cublasStatus_t status;
 #endif
 
 	switch (s)

--- a/examples/heat/dw_factolu_kernels.c
+++ b/examples/heat/dw_factolu_kernels.c
@@ -24,7 +24,6 @@
 #endif
 
 #ifdef STARPU_USE_CUDA
-#include <cublas.h>
 #include <starpu_cublas_v2.h>
 static const float p1 =  1.0;
 static const float m1 = -1.0;
@@ -132,7 +131,7 @@ static inline void dw_common_cpu_codelet_update_gemm(void *descr[], int s, void 
 	unsigned ld22 = STARPU_MATRIX_GET_LD(descr[2]);
 
 #ifdef STARPU_USE_CUDA
-	cublasStatus status;
+	cublasStatus_t status;
 #endif
 
 	switch (s)
@@ -198,7 +197,7 @@ static inline void dw_common_codelet_update_trsm_ll(void *descr[], int s, void *
 	unsigned ny12 = STARPU_MATRIX_GET_NY(descr[1]);
 
 #ifdef STARPU_USE_CUDA
-	cublasStatus status;
+	cublasStatus_t status;
 #endif
 
 	/* solve L11 U12 = A12 (find U12) */
@@ -263,7 +262,7 @@ static inline void dw_common_codelet_update_trsm_ru(void *descr[], int s, void *
 	unsigned ny21 = STARPU_MATRIX_GET_NY(descr[1]);
 
 #ifdef STARPU_USE_CUDA
-	cublasStatus status;
+	cublasStatus_t status;
 #endif
 
 	switch (s)

--- a/examples/lu/xlu_kernels.c
+++ b/examples/lu/xlu_kernels.c
@@ -21,7 +21,6 @@
 #include <complex.h>
 
 #ifdef STARPU_USE_CUDA
-#include <cublas.h>
 #include <starpu_cublas_v2.h>
 #endif
 
@@ -54,7 +53,7 @@ static inline void STARPU_LU(common_gemm)(void *descr[], int s, void *_args)
 	unsigned ld22 = STARPU_MATRIX_GET_LD(descr[2]);
 
 #ifdef STARPU_USE_CUDA
-	cublasStatus status;
+	cublasStatus_t status;
 #endif
 
 	switch (s)
@@ -179,7 +178,7 @@ static inline void STARPU_LU(common_trsmll)(void *descr[], int s, void *_args)
 	unsigned ny12 = STARPU_MATRIX_GET_NY(descr[1]);
 
 #ifdef STARPU_USE_CUDA
-	cublasStatus status;
+	cublasStatus_t status;
 #endif
 
 	/* solve L11 U12 = A12 (find U12) */
@@ -269,7 +268,7 @@ static inline void STARPU_LU(common_trsmru)(void *descr[], int s, void *_args)
 	unsigned ny21 = STARPU_MATRIX_GET_NY(descr[1]);
 
 #ifdef STARPU_USE_CUDA
-	cublasStatus status;
+	cublasStatus_t status;
 #endif
 
 	switch (s)
@@ -355,7 +354,7 @@ static inline void STARPU_LU(common_getrf)(void *descr[], int s, void *_args)
 	unsigned long z;
 
 #ifdef STARPU_USE_CUDA
-	cublasStatus status;
+	cublasStatus_t status;
 	cublasHandle_t handle;
 	cudaStream_t stream;
 #endif
@@ -479,7 +478,7 @@ static inline void STARPU_LU(common_getrf_pivot)(void *descr[],
 	unsigned first = piv->first;
 
 #ifdef STARPU_USE_CUDA
-	cublasStatus status;
+	cublasStatus_t status;
 	cublasHandle_t handle;
 	cudaStream_t stream;
 #endif
@@ -650,7 +649,7 @@ static inline void STARPU_LU(common_pivot)(void *descr[],
 	unsigned first = piv->first;
 
 #ifdef STARPU_USE_CUDA
-	cublasStatus status;
+	cublasStatus_t status;
 	cublasHandle_t handle;
 #endif
 

--- a/mpi/examples/matrix_decomposition/mpi_cholesky_kernels.c
+++ b/mpi/examples/matrix_decomposition/mpi_cholesky_kernels.c
@@ -20,7 +20,6 @@
 #ifdef STARPU_USE_CUDA
 #include <cuda.h>
 #include <cuda_runtime.h>
-#include <cublas.h>
 #include <starpu_cublas_v2.h>
 #ifdef STARPU_HAVE_MAGMA
 #include "magma.h"
@@ -170,7 +169,7 @@ static inline void chol_common_codelet_update_trsm(void *descr[], int s, void *_
 	unsigned ny21 = STARPU_MATRIX_GET_NX(descr[1]);
 
 #ifdef STARPU_USE_CUDA
-	cublasStatus status;
+	cublasStatus_t status;
 #endif
 
 	switch (s)

--- a/sc_hypervisor/examples/cholesky/cholesky_kernels.c
+++ b/sc_hypervisor/examples/cholesky/cholesky_kernels.c
@@ -19,7 +19,6 @@
 //#include "../common/blas.h"
 #ifdef STARPU_USE_CUDA
 #include <starpu_cuda.h>
-#include <cublas.h>
 #include <starpu_cublas_v2.h>
 #ifdef STARPU_HAVE_MAGMA
 #include "magma.h"
@@ -191,7 +190,7 @@ static inline void chol_common_codelet_update_trsm(void *descr[], int s, void *_
 	unsigned ny21 = STARPU_MATRIX_GET_NX(descr[1]);
 
 #ifdef STARPU_USE_CUDA
-	cublasStatus status;
+	cublasStatus_t status;
 #endif
 
 	switch (s)

--- a/src/drivers/cuda/starpu_cublas.c
+++ b/src/drivers/cuda/starpu_cublas.c
@@ -52,7 +52,7 @@ static void init_cublas_func(void *args STARPU_ATTRIBUTE_UNUSED)
 	STARPU_PTHREAD_MUTEX_LOCK(&mutex[devid]);
 	if (!(cublas_initialized[idx]++))
 	{
-		cublasStatus cublasst = cublasInit();
+		cublasStatus_t cublasst = cublasInit();
 		if (STARPU_UNLIKELY(cublasst))
 			STARPU_CUBLAS_REPORT_ERROR(cublasst);
 	}

--- a/tools/dev/experimental/use_starpu_cublas_report_error.cocci
+++ b/tools/dev/experimental/use_starpu_cublas_report_error.cocci
@@ -30,7 +30,7 @@ virtual report
 // 		STARPU_ABORT();
 //
 @starpu_abort@
-cublasStatus status;
+cublasStatus_t status;
 position p;
 @@
 status = cublasGetError();
@@ -53,7 +53,7 @@ p << starpu_abort.p;
 coccilib.org.print_todo(p[0], "Use STARPU_CUBLAS_REPORT_ERROR() instead of STARPU_ABORT().")
 
 @depends on starpu_abort && patch@
-cublasStatus starpu_abort.status;
+cublasStatus_t starpu_abort.status;
 position starpu_abort.p;
 @@
 - STARPU_ABORT@p();
@@ -71,7 +71,7 @@ coccilib.report.print_report(p[0], "Use STARPU_CUBLAS_REPORT_ERROR() instead of 
 // 	status = cublasGetError();
 // 	STARPU_ASSERT(!status);
 @starpu_assert@
-cublasStatus status;
+cublasStatus_t status;
 position p;
 @@
 status = cublasGetError();
@@ -90,7 +90,7 @@ coccilib.org.print_todo(p[0], "Use STARPU_CUBLAS_REPORT_ERROR() instead of STARP
 
 @depends on starpu_assert && patch@
 position starpu_assert.p;
-cublasStatus starpu_assert.status;
+cublasStatus_t starpu_assert.status;
 @@
 - STARPU_ASSERT@p(!status);
 + if (STARPU_UNLIKELY(status != CUBLAS_STATUS_SUCCESS))

--- a/tools/dev/experimental/use_starpu_cublas_report_error_test.c
+++ b/tools/dev/experimental/use_starpu_cublas_report_error_test.c
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License in COPYING.LGPL for more details.
  */
 
-static cublasStatus st;
+static cublasStatus_t st;
 
 static void
 bad_0(void)


### PR DESCRIPTION
Closes #9.

Issue #9 wasn't completely solved with 37498c5. This is an attempt to complete the changes from 37498c5.

Changes:
1. `cublasStatus` changes to `cublasStatus_t`
2. `starpu_cublas_v2.h` is no more included together with `cublas.h`. 