### PR TITLE
Fix missing CL_CALLBACK for various callback functions

### DIFF
--- a/socl/src/cl_buildprogram.c
+++ b/socl/src/cl_buildprogram.c
@@ -80,7 +80,7 @@ soclBuildProgram(cl_program         program,
 		 cl_uint              num_devices,
 		 const cl_device_id * device_list,
 		 const char *         options,
-		 void (*pfn_notify)(cl_program program, void * user_data),
+		 void (CL_CALLBACK *pfn_notify)(cl_program program, void * user_data),
 		 void *               user_data)
 {
 	struct bp_data *data;

--- a/socl/src/cl_createcontext.c
+++ b/socl/src/cl_createcontext.c
@@ -38,7 +38,7 @@ CL_API_ENTRY cl_context CL_API_CALL
 soclCreateContext(const cl_context_properties * properties,
 		  cl_uint                       num_devices,
 		  const cl_device_id *          devices,
-		  void (*pfn_notify)(const char *, const void *, size_t, void *),
+		  void (CL_CALLBACK *pfn_notify)(const char *, const void *, size_t, void *),
 		  void *                        user_data,
 		  cl_int *                      errcode_ret)
 {

--- a/socl/src/cl_createcontextfromtype.c
+++ b/socl/src/cl_createcontextfromtype.c
@@ -22,7 +22,7 @@ CL_API_SUFFIX__VERSION_1_0
 CL_API_ENTRY cl_context CL_API_CALL
 soclCreateContextFromType(const cl_context_properties * properties,
 			  cl_device_type                device_type,
-			  void (*pfn_notify)(const char *, const void *, size_t, void *),
+			  void (CL_CALLBACK *pfn_notify)(const char *, const void *, size_t, void *),
 			  void *                        user_data,
 			  cl_int *                      errcode_ret)
 {

--- a/socl/src/socl.h
+++ b/socl/src/socl.h
@@ -113,7 +113,7 @@ struct _cl_context
 {
 	CL_ENTITY;
 
-	void (*pfn_notify)(const char *, const void *, size_t, void *);
+	void (CL_CALLBACK *pfn_notify)(const char *, const void *, size_t, void *);
 	void *user_data;
 
 	/* Associated devices */
@@ -330,14 +330,14 @@ extern CL_API_ENTRY cl_context CL_API_CALL
 soclCreateContext(const cl_context_properties * /* properties */,
 		  cl_uint                       /* num_devices */,
 		  const cl_device_id *          /* devices */,
-		  void (*pfn_notify)(const char *, const void *, size_t, void *) /* pfn_notify */,
+		  void (CL_CALLBACK *pfn_notify)(const char *, const void *, size_t, void *) /* pfn_notify */,
 		  void *                        /* user_data */,
 		  cl_int *                      /* errcode_ret */) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_context CL_API_CALL
 soclCreateContextFromType(const cl_context_properties * /* properties */,
 			  cl_device_type                /* device_type */,
-			  void (*pfn_notify)(const char *, const void *, size_t, void *) /* pfn_notify */,
+			  void (CL_CALLBACK *pfn_notify)(const char *, const void *, size_t, void *) /* pfn_notify */,
 			  void *                        /* user_data */,
 			  cl_int *                      /* errcode_ret */) CL_API_SUFFIX__VERSION_1_0;
 
@@ -487,7 +487,7 @@ soclBuildProgram(cl_program           /* program */,
 		 cl_uint              /* num_devices */,
 		 const cl_device_id * /* device_list */,
 		 const char *         /* options */,
-		 void (*pfn_notify)(cl_program /* program */, void * /* user_data */),
+		 void (CL_CALLBACK *pfn_notify)(cl_program /* program */, void * /* user_data */),
 		 void *               /* user_data */) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL


### PR DESCRIPTION
_cl_icd_dispatch declares these function pointers with CL_CALLBACK which expands to __stdcall, which is not the default on 32bit Windows.

Make sure to use CL_CALLBACK in all functions assigned to it, so the right calling convention is used.

This is also motivated by clang v16 now erroring out because of this.