### PR TITLE
Prevent codelets from being modified inside (at least) some tasks

### DIFF
--- a/src/drivers/driver_common/driver_common.c
+++ b/src/drivers/driver_common/driver_common.c
@@ -88,7 +88,8 @@ void _starpu_driver_start_job(struct _starpu_worker *worker, struct _starpu_job 
 		task->status = STARPU_TASK_RUNNING;
 
 		STARPU_AYU_RUNTASK(j->job_id);
-		cl->per_worker_stats[workerid]++;
+		if (profiling && profiling_info)
+			cl->per_worker_stats[workerid]++;
 
 		if ((profiling && profiling_info) || calibrate_model || !_starpu_perf_counter_paused())
 		{

--- a/src/drivers/driver_common/driver_common.c
+++ b/src/drivers/driver_common/driver_common.c
@@ -88,7 +88,7 @@ void _starpu_driver_start_job(struct _starpu_worker *worker, struct _starpu_job 
 		task->status = STARPU_TASK_RUNNING;
 
 		STARPU_AYU_RUNTASK(j->job_id);
-		if (profiling && profiling_info)
+		if (profiling)
 			cl->per_worker_stats[workerid]++;
 
 		if ((profiling && profiling_info) || calibrate_model || !_starpu_perf_counter_paused())


### PR DESCRIPTION
This PR makes a minor change that prevents codelets from being modified inside (at least) some tasks, when profiling is disabled.

With this change, codelets could be implemented as static constant expressions. Right now, as I noticed in the StarPU examples, codelets need to be "global" non-const variables. By "global", I mean: "not associated to the local scope where the task is defined". 

Global variables are bad for C++ template libraries. The reason: global variables cannot be on header files, they should be either on the application executable or inside the compiled library. In the current state of StarPU, we would need to dynamically allocate space for codelets if their creation depend on template arguments. Since codelets are not that small (704B) and since dynamic memory allocation can be expensive, I would like to avoid it.

In the future, users (me included) could need both (1) profiling and (2) codelets working as constant static expressions. In this case, maybe there is a way to disable only functions reading information from `per_worker_stats`, which currently are `starpu_codelet_display_stats()` and `starpu_bound_print_lp()`.