### PR TITLE
Fix for communicator bug in MPI cache

### DIFF
--- a/include/starpu_task.h
+++ b/include/starpu_task.h
@@ -2096,6 +2096,7 @@ char *starpu_task_status_get_as_string(enum starpu_task_status status);
    See \ref HowToReduceTheMemoryFootprintOfInternalDataStructures for more details.
 */
 void starpu_set_limit_min_submitted_tasks(int limit_min);
+int starpu_get_limit_min_submitted_tasks();
 
 /**
    Specify a maximum number of submitted tasks allowed at a given
@@ -2105,6 +2106,7 @@ void starpu_set_limit_min_submitted_tasks(int limit_min);
    See \ref HowToReduceTheMemoryFootprintOfInternalDataStructures for more details.
 */
 void starpu_set_limit_max_submitted_tasks(int limit_min);
+int starpu_get_limit_max_submitted_tasks();
 
 /** @} */
 

--- a/mpi/include/starpu_mpi.h
+++ b/mpi/include/starpu_mpi.h
@@ -504,7 +504,7 @@ int starpu_mpi_cached_send(starpu_data_handle_t data_handle, int dest);
  * add it to the cache and return 0
  * Return 0 if the communication cache is not enabled
  */
-int starpu_mpi_cached_send_set(starpu_data_handle_t data, int dest);
+int starpu_mpi_cached_send_set(starpu_data_handle_t data, int dest, MPI_Comm comm);
 
 /**
  * Remove \p data from the emission cache

--- a/mpi/src/starpu_mpi.c
+++ b/mpi/src/starpu_mpi.c
@@ -323,7 +323,7 @@ int starpu_mpi_issend_detached(starpu_data_handle_t data_handle, int dest, starp
 struct _starpu_mpi_req* _starpu_mpi_isend_cache_aware(starpu_data_handle_t data_handle, int dest, starpu_mpi_tag_t data_tag, MPI_Comm comm, unsigned detached, unsigned sync, int prio, void (*callback)(void *), void *_arg, int sequential_consistency, int* cache_flag)
 {
 	struct _starpu_mpi_req* req = NULL;
-	int already_sent = starpu_mpi_cached_send_set(data_handle, dest);
+	int already_sent = starpu_mpi_cached_send_set(data_handle, dest, comm);
 	if (already_sent == 0)
 	{
 		*cache_flag = 0;
@@ -595,7 +595,7 @@ int starpu_mpi_get_data_on_node_detached(MPI_Comm comm, starpu_data_handle_t dat
 	else if (me == rank)
 	{
 		_STARPU_MPI_DEBUG(1, "Migrating data %p from %d to %d\n", data_handle, rank, node);
-		int already_sent = starpu_mpi_cached_send_set(data_handle, node);
+		int already_sent = starpu_mpi_cached_send_set(data_handle, node, comm);
 		if (already_sent == 0)
 		{
 			_STARPU_MPI_DEBUG(1, "Sending data %p to %d\n", data_handle, node);
@@ -640,7 +640,7 @@ int starpu_mpi_get_data_on_node(MPI_Comm comm, starpu_data_handle_t data_handle,
 	else if (me == rank)
 	{
 		_STARPU_MPI_DEBUG(1, "Migrating data %p from %d to %d\n", data_handle, rank, node);
-		int already_sent = starpu_mpi_cached_send_set(data_handle, node);
+		int already_sent = starpu_mpi_cached_send_set(data_handle, node, comm);
 		if (already_sent == 0)
 		{
 			_STARPU_MPI_DEBUG(1, "Sending data %p to %d\n", data_handle, node);

--- a/mpi/src/starpu_mpi_task_insert.c
+++ b/mpi/src/starpu_mpi_task_insert.c
@@ -151,7 +151,7 @@ int _starpu_mpi_exchange_data_before_execution(starpu_data_handle_t data, enum s
 		if (!do_execute && mpi_rank == me)
 		{
 			/* The node owns the data, but another node is going to execute the codelet, the node needs to send the data to the executee node. */
-			int already_sent = starpu_mpi_cached_send_set(data, xrank);
+			int already_sent = starpu_mpi_cached_send_set(data, xrank, comm);
 			if (already_sent == 0)
 			{
 				if (data_tag == -1)

--- a/src/core/task.c
+++ b/src/core/task.c
@@ -338,6 +338,16 @@ static nosv_task_type_t starpu_nosv_get_task_type_from_codelet(struct starpu_cod
 }
 #endif
 
+int starpu_get_limit_min_submitted_tasks()
+{
+	return limit_min_submitted_tasks;
+}
+
+int starpu_get_limit_max_submitted_tasks()
+{
+	return limit_max_submitted_tasks;
+}
+
 void starpu_set_limit_min_submitted_tasks(int limit_min)
 {
 	limit_min_submitted_tasks = limit_min;


### PR DESCRIPTION
Added rank translation from the MPI communicator of the task to `MPI_COMM_WORLD` when checking if data needs to be exchanged before execution. This mitigates the issue raised in [https://sympa.inria.fr/sympa/arc/starpu-devel/2024-12/msg00001.html](https://sympa.inria.fr/sympa/arc/starpu-devel/2024-12/msg00001.html) and avoids StarPU mistakenly believing that some data has already been sent to a node that has the same rank as another node in some communicator.

The fix is somewhat slow (~1-2µs per translation); a better way would be to precompute all rank translations into a lookup table when registering new MPI communicators to StarPU.